### PR TITLE
Fix LLVM/Clang build error when targeting C23

### DIFF
--- a/src/data.h
+++ b/src/data.h
@@ -4,11 +4,11 @@
 #include "defs.h"
 
 // JPEG block coordinates in zig-zag order (mapping cell indexes to (x, y) coordinates)
-static const alignto(64) uint8_t JPEG_zigzag_rows[] = {
+alignto(64) static const uint8_t JPEG_zigzag_rows[] = {
   0, 0, 1, 2, 1, 0, 0, 1, 2, 3, 4, 3, 2, 1, 0, 0, 1, 2, 3, 4, 5, 6, 5, 4, 3, 2, 1, 0, 0, 1, 2, 3,
   4, 5, 6, 7, 7, 6, 5, 4, 3, 2, 1, 2, 3, 4, 5, 6, 7, 7, 6, 5, 4, 3, 4, 5, 6, 7, 7, 6, 5, 6, 7, 7
 };
-static const alignto(64) uint8_t JPEG_zigzag_columns[] = {
+alignto(64) static const uint8_t JPEG_zigzag_columns[] = {
   0, 1, 0, 0, 1, 2, 3, 2, 1, 0, 0, 1, 2, 3, 4, 5, 4, 3, 2, 1, 0, 0, 1, 2, 3, 4, 5, 6, 7, 6, 5, 4,
   3, 2, 1, 0, 1, 2, 3, 4, 5, 6, 7, 7, 6, 5, 4, 3, 2, 3, 4, 5, 6, 7, 7, 6, 5, 4, 5, 6, 7, 7, 6, 7
 };


### PR DESCRIPTION
Clang generates the following error when `alignas` appears after `static const` when targeting C23:
```c
build/libplum.c:599:14: error: 'alignas' attribute cannot be applied to types
  599 | static const alignto(64) uint8_t JPEG_zigzag_rows[] = {
      |              ^
build/libplum.c:39:25: note: expanded from macro 'alignto'
   39 | #define alignto(amount) alignas(((amount) < alignof(max_align_t)) ? (amount) : alignof(max_align_t))
      |                         ^

```
This PR should fix that error