### PR TITLE
Fix build on macOS

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,4 +7,4 @@
 *.sh text
 *.png binary
 LICENSE text
-Makefile text
+GNUmakefile text

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,8 +1,16 @@
+HAVE_UNAME := $(shell command -v uname >/dev/null 2>&1 && echo 1)
+UNAME_S := $(if $(HAVE_UNAME),$(shell uname -s),)
+
 CC ?= gcc
 OUTPUT ?= libplum.so
 OPTFLAGS = -march=native -mtune=native
 
-CFLAGS = -std=c17 -Ofast -fomit-frame-pointer -fno-asynchronous-unwind-tables -fno-exceptions -Wl,-S -Wl,-x -Wl,--gc-sections $(OPTFLAGS)
+DEFAULTCFLAGS := -std=c17 -Ofast -fomit-frame-pointer -fno-asynchronous-unwind-tables -fno-exceptions -Wl,-S -Wl,-x
+ifeq ($(UNAME_S),Darwin)
+	CFLAGS = $(DEFAULTCFLAGS) $(OPTFLAGS)
+else
+	CFLAGS = $(DEFAULTCFLAGS) -Wl,--gc-sections $(OPTFLAGS)
+endif
 
 DEBUGFLAGS = -Wall -Wextra -pedantic -Wnull-dereference -Wshadow -Wundef -Wunused -Wwrite-strings -Wno-sign-compare -Wno-implicit-fallthrough \
              -Wno-parentheses -Wno-dangling-else -Wno-type-limits

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,16 +1,12 @@
-HAVE_UNAME := $(shell command -v uname >/dev/null 2>&1 && echo 1)
-UNAME_S := $(if $(HAVE_UNAME),$(shell uname -s),)
-
 CC ?= gcc
 OUTPUT ?= libplum.so
 OPTFLAGS = -march=native -mtune=native
 
 DEFAULTCFLAGS := -std=c17 -Ofast -fomit-frame-pointer -fno-asynchronous-unwind-tables -fno-exceptions -Wl,-S -Wl,-x
-ifeq ($(UNAME_S),Darwin)
-	CFLAGS = $(DEFAULTCFLAGS) $(OPTFLAGS)
-else
-	CFLAGS = $(DEFAULTCFLAGS) -Wl,--gc-sections $(OPTFLAGS)
+ifeq ($(shell echo 'int main(){return 0;}' | $(CC) -xc -Wl,--gc-sections - >/dev/null 2>&1 && echo 1),1)
+	DEFAULTCFLAGS += -Wl,--gc-sections
 endif
+CFLAGS = $(DEFAULTCFLAGS) $(OPTFLAGS)
 
 DEBUGFLAGS = -Wall -Wextra -pedantic -Wnull-dereference -Wshadow -Wundef -Wunused -Wwrite-strings -Wno-sign-compare -Wno-implicit-fallthrough \
              -Wno-parentheses -Wno-dangling-else -Wno-type-limits

--- a/docs/building.md
+++ b/docs/building.md
@@ -11,9 +11,9 @@ It has no dependencies besides what the C standard requires; the source of the l
 
 The build process will generate three files in the `build` directory (creating it if needed): `libplum.c`, `libplum.h`
 and the library's shared binary (`libplum.so` by default).
-To build the library, you will need `make` and a Bash shell; simply run `make`.
+To build the library, you will need GNU `make` and a Bash shell; simply run `make` (or `gmake` if that is its name).
 The default configuration assumes a GCC-like compiler; for a completely different compiler (like MSVC), the flags (and
-perhaps the Makefile itself) will most likely need customization.
+perhaps the GNUmakefile itself) will most likely need customization.
 The following variables can be specified in the `make` command:
 
 - `CC`: C compiler binary; will be read from the environment if it exists.

--- a/merge.sh
+++ b/merge.sh
@@ -1,12 +1,17 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 declare -A files
 addblank=false
 
 function append_file {
-  local file="`realpath "$1"`"
-  [[ ! -n ${files[$file]} ]] || return 0
+  local file
+  if command -v grealpath >/dev/null 2>&1; then
+    file="$(grealpath "$1")"
+  else
+    file="$(realpath "$1")"
+  fi
+  [[ -z ${files[$file]} ]] || return 0
   ! $addblank || echo
   addblank=false
   files["$file"]=true


### PR DESCRIPTION
Fixes #16
Closes #17

To recap: macOS (and to a lesser extend BSD) has some out-of-the-box limitations that prevent a simple `make` command from building this repo for me.

- `/bin/bash` is version 3.2.57 from 2007, which did not support `declare -A`.
  - **Solution:** use `/usr/bin/env bash`, which detects the newer Bash shell installed by Homebrew or MacPorts.
- `gcc` and `cc` are links to `clang`, which does not support `-Wl,--gc-sections`.
  - ~~**Solution:** check the OS with `$(shell uname -s)` and only add that to `CFLAGS` if it's not macOS. (If `uname` does not exist, assume Windows, or at least assume "not macOS with the system compiler".)~~
  - **Better solution:** do a test run of the compiler with `$(shell $(CC) -Wl,--gc-sections ...)`, and only add that to `CFLAGS` if it succeeds. (Source: [StackOverflow](https://stackoverflow.com/a/61634784))
- `$(shell)` is a GNU make feature, not supported by BSD make.
  - **Solution:** require GNU make (installed as `gmake` from Homebrew or MacPorts, also commonly installed as `gmake` on BSD) and rename Makefile to GNUmakefile to indicate this dependency.
- `realpath` was not available on macOS until version 13 Ventura, and my hardware can't upgrade past 11.7 Big Sur.
  - **Solution:** if `grealpath` (another GNU utility commonly installed from Homebrew or MacPorts) exists, use that instead.

This also fixes a couple of things that [shellcheck](https://www.shellcheck.net/) complained about in merge.sh:

- ``local file="`realpath "$1"`"``
  - [SC2155](https://www.shellcheck.net/wiki/SC2155) (warning): Declare and assign separately to avoid masking return values.
  - [SC2006](https://www.shellcheck.net/wiki/SC2006) (style): Use `$(...)` notation instead of legacy backticks `` `...` ``.
- `[[ ! -n ${files[$file]} ]] || return 0`
  - [SC2236](https://www.shellcheck.net/wiki/SC2236) (style): Use `-z` instead of `! -n`.
